### PR TITLE
Remove SMTP completely

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,8 +64,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
-
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/smtp.rb
+++ b/config/smtp.rb
@@ -1,9 +1,0 @@
-SMTP_SETTINGS = {
-  address: ENV.fetch("SMTP_ADDRESS"), # example: "smtp.sendgrid.net"
-  authentication: :plain,
-  domain: ENV.fetch("SMTP_DOMAIN"), # example: "this-app.com"
-  enable_starttls_auto: true,
-  password: ENV.fetch("SMTP_PASSWORD"),
-  port: "587",
-  user_name: ENV.fetch("SMTP_USERNAME")
-}


### PR DESCRIPTION
We are not emailing and don't have any current plans to email. Having to set
those keys to blank doesn't provide any benefit.