### PR TITLE
Improve the CircleCI Config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ machine:
     America/New_York
 checkout:
   post:
+    - cp .sample.env .env
+database:
+  override:
     - bin/setup
 deployment:
   production:

--- a/lib/tasks/development_seeds.rake
+++ b/lib/tasks/development_seeds.rake
@@ -1,4 +1,4 @@
-if Rails.env.development?
+if Rails.env.development? || Rails.env.test?
   require "factory_girl"
 
   namespace :dev do


### PR DESCRIPTION
* Speed up the entire process, this allows us to be able to utilize the bundle cache. Moving the test time down from around 5 minutes to 2 minutes.
* Remove the `rake dev:prime` call. We don't have a `dev:prime` currently.