### PR TITLE
Always show a unique list of PRs

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -16,7 +16,10 @@ class PullRequestsController < ApplicationController
   end
 
   def pull_requests
-    @pull_requests ||= PullRequest.for_tags(tags_to_filter_by).active
+    @pull_requests ||= PullRequest.
+      for_tags(tags_to_filter_by).
+      active.
+      uniq
   end
 
   def tags

--- a/spec/features/user_views_prs_spec.rb
+++ b/spec/features/user_views_prs_spec.rb
@@ -116,9 +116,9 @@ feature "User views PRs" do
       click_on "rails"
     end
 
-    expect(page).to have_content("An Ember PR")
-    expect(page).to have_content("A Rails PR")
-    expect(page).to have_content("A long pr")
+    expect(page).to have_content("An Ember PR", count: 1)
+    expect(page).to have_content("A Rails PR", count: 1)
+    expect(page).to have_content("A long pr", count: 1)
   end
 
   scenario "Can remove a tag from filtered tags" do


### PR DESCRIPTION
This prevents PRs from showing up more than once when they match on multiple tag
filters.

Fixes #108.