### PR TITLE
Change REPOST_THRESHOLD value to string

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
     "REPOST_THRESHOLD": {
       "description": "The time threshold to determine when to repost the PR.",
       "required": true,
-      "value": 30
+      "value": "30"
     },
     "WEBHOOK_URL": {
       "description": "Where users should send their github payloads",


### PR DESCRIPTION
Heroku expects strings or objects in their app.son and isn't allowing users to create new applications with the "Deploy to Heroku" button. This small change should make Heroku work again